### PR TITLE
expose a print-abbreviations-inline function to make abbreviations in footnotes nicer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ References are clever, bracketed and with support for two-example references via
 
 Common judges are recognized automatically. `judge` typesets text without taking up space.
 
-The `abbreviations` submodule provides `leipzig`-style abbreviation commands. They are kept track of and can be printed with `print-abbreviations`.
+The `abbreviations` submodule provides `leipzig`-style abbreviation commands. The abbreviations used are kept track of and can be printed with `print-abbreviations` or `print-abbreviations-inline`.
 
 Customization is done via the global show rule: `#show eggs.with()`.
 

--- a/documentation.typ
+++ b/documentation.typ
@@ -1,7 +1,7 @@
 #set document(title: "typst eggs documentation")
 #let version = "0.7.1"
 
-#import "eggs.typ": abbreviations, example, gloss, judge, subexample, eggs, abbreviation, print-abbreviations, ex-label, ex-ref
+#import "eggs.typ": abbreviations, example, gloss, judge, subexample, eggs, abbreviation, print-abbreviations, print-abbreviations-inline, ex-label, ex-ref
 #import "@preview/tidy:0.4.3"
 
 #show: eggs
@@ -26,7 +26,7 @@
       #eval(
         text,
         mode: "markup",
-        scope: (eggs: eggs, example: example, gloss: gloss, subexample: subexample, judge: judge, abbreviations: abbreviations, abbreviation: abbreviation, print-abbreviations: print-abbreviations, ex-label: ex-label, ex-ref: ex-ref)
+        scope: (eggs: eggs, example: example, gloss: gloss, subexample: subexample, judge: judge, abbreviations: abbreviations, abbreviation: abbreviation, print-abbreviations: print-abbreviations, print-abbreviations-inline: print-abbreviations-inline, ex-label: ex-label, ex-ref: ex-ref)
       )
     ]}
   ]
@@ -277,11 +277,11 @@ Custom abbreviations can be created by defining a new `abbreviation`.
   ```
 )
 
-The list of currently used abbreviations is stored as a dictionary of the form `abbr: description` inside the `used-abbreviations` state. The final list of abbreviations can be accessed as #raw("#context state(\"used-abbreviations\").final()", lang: "typst"). There is also a function to print it as a #link("https://typst.app/docs/reference/model/terms/")[term~list].
+The list of currently used abbreviations is stored as a dictionary of the form `abbr: description` inside the `used-abbreviations` state. The final list of abbreviations can be accessed as #raw("#context state(\"used-abbreviations\").final()", lang: "typst"), or printed as a #link("https://typst.app/docs/reference/model/terms/")[term~list] via `print-abbreviations` or inline via `print-abbreviations-inline`.
 
 #code-ex(
   ```typst
-  The list of glossing abbreviations used in this paper:
+  The list of glossing abbreviations used in this paper are the following:
   #print-abbreviations()
   ```
 )

--- a/eggs.typ
+++ b/eggs.typ
@@ -1,5 +1,5 @@
 #import "src/abbreviations.typ"
-#import abbreviations: abbreviation, print-abbreviations
+#import abbreviations: abbreviation, print-abbreviations, print-abbreviations-inline
 #import "src/gloss.typ": gloss
 #import "src/example.typ": example, subexample
 #import "src/ex-label.typ": ex-label

--- a/src/abbreviations.typ
+++ b/src/abbreviations.typ
@@ -23,6 +23,22 @@
   }
 }
 
+/// Prints the list of abbreviations used in the document as an inline list.
+///
+/// - sorted-by (function): A callback function to sort abbreviations by.
+///   Takes in a left and a right abbreviation and returns a boolean.
+///   To sort by order of use, pass `(_, _) => true`.
+///
+///   *Default*: Alphabetical. `(l, r) => l <= r`
+///
+/// -> content
+#let print-abbreviations-inline(sorted-by: (l, r) => l <= r) = {
+  context {
+    let used = used-abbreviations.final()
+    used.pairs().sorted(key: k => k.at(0), by: sorted-by).map(((abbr, desc)) => [#smallcaps(abbr) = #desc]).join(", ")
+  }
+}
+
 /// Prints the symbol in smallcaps
 /// and adds it to the list of used abbreviations.
 ///


### PR DESCRIPTION
I am currently having a go at recreating my university's LaTeX template / style guide in Typst. I encountered this footnote:

<img width="614" height="67" alt="image" src="https://github.com/user-attachments/assets/90f286b1-866c-4c99-a5bc-762e172274f6" />

This merge request adds a `print-abbreviations-inline` to handle this (I think quite common) case.

Thought it also might be worth considering exposing a nice `get-abbreviations` function that does the `context state("used-abbreviations").final()` and `.pairs()` stuff for the user, instead. But, this would be maybe more of a pain than it's worth, since it'd have to return a content block (re: context)...