### PR TITLE
support for hanging indents

### DIFF
--- a/src/config.typ
+++ b/src/config.typ
@@ -137,6 +137,10 @@
 ///
 ///   *Default*: current `par.leading`.
 ///
+/// - gloss-leading (length): Vertical spacing between between blocks of (wrapped) glosses.
+///
+///   *Default*: current `par.leading`.
+///
 /// - gloss-hanging-indent (length): Horizontal spacing before wrapped gloss lines.
 ///
 ///   *Default*: 1em
@@ -179,6 +183,7 @@
   gloss-line-spacing: auto,
   gloss-before-spacing: auto,
   gloss-after-spacing: auto,
+  gloss-leading: auto,
   gloss-hanging-indent: auto,
   gloss-styles: auto,
 ) = {
@@ -235,6 +240,7 @@
     ("line-spacing", gloss-line-spacing),
     ("before-spacing", gloss-before-spacing),
     ("after-spacing", gloss-after-spacing),
+    ("leading", gloss-leading),
     ("hanging-indent", gloss-hanging-indent),
     ("styles", gloss-styles),
   )

--- a/src/config.typ
+++ b/src/config.typ
@@ -137,6 +137,10 @@
 ///
 ///   *Default*: current `par.leading`.
 ///
+/// - gloss-hanging-indent (length): Horizontal spacing before wrapped gloss lines.
+///
+///   *Default*: 1em
+///
 /// - gloss-styles (array): List of functions to be applied to each line of glosses.
 ///   Can be of any length. `gloss-styles[0]` is applied to the first line,
 ///   `gloss-styles[1]` --- to the second, etc.
@@ -175,6 +179,7 @@
   gloss-line-spacing: auto,
   gloss-before-spacing: auto,
   gloss-after-spacing: auto,
+  gloss-hanging-indent: auto,
   gloss-styles: auto,
 ) = {
   show: e.prepare()
@@ -230,6 +235,7 @@
     ("line-spacing", gloss-line-spacing),
     ("before-spacing", gloss-before-spacing),
     ("after-spacing", gloss-after-spacing),
+    ("hanging-indent", gloss-hanging-indent),
     ("styles", gloss-styles),
   )
 

--- a/src/gloss.typ
+++ b/src/gloss.typ
@@ -3,8 +3,7 @@
 #import "judge.typ": format-judges
 #import "utils.typ": auto-length, prefix, gen-get-function, split-content
 
-// take a martix of words
-// and assemble it into a gloss grid
+// take a matrix of words and assemble it into a gloss grid
 #let build-gloss-grid(
   lines,
   styles: (),
@@ -13,28 +12,31 @@
   after-spacing: auto,
   line-spacing: auto,
   word-spacing: auto,
+  hanging-indent: auto,
 ) = {
   let length = lines.at(0).len()
   block(
     above: before-spacing,
     below: after-spacing,
 
-    // turn list of lines into list of columns
-    lines.at(0).zip(..lines.slice(1))
-    .map(words => {
-      box(
-        grid(
-          row-gutter: line-spacing,
-          ..words
-            // parse each word for auto judges
-            .map(format-judges.with(auto-judges: auto-judges))
-            // apply corresponding styling to each word
-            .zip(styles)
-            .map(((word, style)) => style(word))
+    par(hanging-indent: hanging-indent,
+      // turn list of lines into list of columns
+      lines.at(0).zip(..lines.slice(1))
+      .map(words => {
+        box(
+          grid(
+            row-gutter: line-spacing,
+            ..words
+              // parse each word for auto judges
+              .map(format-judges.with(auto-judges: auto-judges))
+              // apply corresponding styling to each word
+              .zip(styles)
+              .map(((word, style)) => style(word))
+          )
         )
-      )
-      h(word-spacing)
-    }).join()
+        h(word-spacing)
+      }).join()
+    )
   )
 }
 
@@ -63,6 +65,10 @@
 /// - after-spacing (length): Vertical spacing below glosses (i.e. before the translation).
 ///
 ///   *Default*: current `par.leading`.
+///
+/// - hanging-indent (length): Horizontal spacing before wrapped gloss lines.
+///
+///   *Default*: 1em
 ///
 /// - styles (array): List of functions to be applied to each line of glosses.
 ///   Can be of any length. `gloss-styles[0]` is applied to the first line,
@@ -95,6 +101,7 @@
     e.field("line-spacing", auto-length, doc: "Vertical spacing between lines in glosses. Defaults to `par.leading`."),
     e.field("before-spacing", auto-length, doc: "Vertical spacing above glosses (i.e. after the preamble). Defaults to `par.leading`."),
     e.field("after-spacing", auto-length, doc: "Vertical spacing below glosses (i.e. before the translation). Defaults to `par.leading`."),
+    e.field("hanging-indent", length, default: 1em, doc: "Horizontal spacing before wrapped gloss lines."),
     e.field("styles", array, doc: "List of functions to be applied to each line of glosses. Can be of any length. `gloss-styles[0]` is applied to the first line, `gloss-styles[1]` --- to the second, etc. E.g. ```typst (emph, it => it + [.])``` makes the first line italicized and adds a period to the second line."),
 
     e.field("get-line-spacing", function, synthesized: true, default: () => par.leading),
@@ -155,6 +162,7 @@
       after-spacing: (elem.get-after-spacing)(),
       line-spacing: (elem.get-line-spacing)(),
       word-spacing: elem.word-spacing,
+      hanging-indent: elem.hanging-indent,
     )
   }
 )

--- a/src/gloss.typ
+++ b/src/gloss.typ
@@ -12,6 +12,7 @@
   after-spacing: auto,
   line-spacing: auto,
   word-spacing: auto,
+  leading: auto,
   hanging-indent: auto,
 ) = {
   let length = lines.at(0).len()
@@ -19,7 +20,7 @@
     above: before-spacing,
     below: after-spacing,
 
-    par(hanging-indent: hanging-indent,
+    par(hanging-indent: hanging-indent, leading: leading,
       // turn list of lines into list of columns
       lines.at(0).zip(..lines.slice(1))
       .map(words => {
@@ -66,6 +67,10 @@
 ///
 ///   *Default*: current `par.leading`.
 ///
+/// - leading (length): Vertical spacing between between blocks of (wrapped) glosses.
+///
+///   *Default*: current `par.leading`.
+///
 /// - hanging-indent (length): Horizontal spacing before wrapped gloss lines.
 ///
 ///   *Default*: 1em
@@ -101,6 +106,7 @@
     e.field("line-spacing", auto-length, doc: "Vertical spacing between lines in glosses. Defaults to `par.leading`."),
     e.field("before-spacing", auto-length, doc: "Vertical spacing above glosses (i.e. after the preamble). Defaults to `par.leading`."),
     e.field("after-spacing", auto-length, doc: "Vertical spacing below glosses (i.e. before the translation). Defaults to `par.leading`."),
+    e.field("leading", auto-length, doc: "Vertical spacing between between blocks of (wrapped) glosses. Defaults to `par.leading`."),
     e.field("hanging-indent", length, default: 1em, doc: "Horizontal spacing before wrapped gloss lines."),
     e.field("styles", array, doc: "List of functions to be applied to each line of glosses. Can be of any length. `gloss-styles[0]` is applied to the first line, `gloss-styles[1]` --- to the second, etc. E.g. ```typst (emph, it => it + [.])``` makes the first line italicized and adds a period to the second line."),
 
@@ -161,6 +167,7 @@
       before-spacing: (elem.get-before-spacing)(),
       after-spacing: (elem.get-after-spacing)(),
       line-spacing: (elem.get-line-spacing)(),
+      leading: (elem.leading)(),
       word-spacing: elem.word-spacing,
       hanging-indent: elem.hanging-indent,
     )


### PR DESCRIPTION
I am working on a re-creation of the LaTeX template of my university's internal linguistics journal (https://typst.app/project/R612EnCrCZF7cSFdVhJicQ). They mandate hanging indents, which made me notice that Eggs doesn't actually have them! It's probably worth having them, and having them by default, even.

Wrapping the output of a gloss in `par` and setting `hanging-indent` appears to work fine.