### PR TITLE
minor cleanups

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Below is an example of how to typeset an example.
 
 ### Basics
 
-Start with applying the global show rule. The central function is `example`, which typesets an example. Inside it, auto-numbered lists (`+`) are treated as subexamples, and bullet lists (`-`) as interlinear gloss lines. **Words in glosses must be separated by two or more spaces**.
+Start with applying the global show rule. The central function is `example`, which typesets an example. Inside it, auto-numbered lists (`+`) are treated as subexamples, and bullet lists (`-`) as interlinear gloss lines.
 
 This automatic conversion can be toggled off by passing `auto-subexamples: false` and `auto-glosses: false` to `example`, like this:
 

--- a/src/example.typ
+++ b/src/example.typ
@@ -188,7 +188,7 @@
       "OK": true,
     ), folds: false, doc: "A dictionary of characters to convert into judges (keys) and whether to superscript them (values)."),
 
-    e.field("indent", length, default: 0em, doc: "Distance between the the left edge of the top-level example body and the left edge of the subexample number."),
+    e.field("indent", length, default: 0em, doc: "Distance between the left edge of the top-level example body and the left edge of the subexample number."),
     e.field("body-indent", length, default: 1.5em, doc: "Distance between the left edge of the subexample marker and the left edge of the subexample body."),
     e.field("spacing", auto-length, default: auto, doc: "Vertical spacing around the subexample. Currently, there is no way to modify spacing between two subexamples specifically."),
     e.field("breakable", bool, default: false, doc: "Whether the subexample figure is breakable."),

--- a/src/gloss.typ
+++ b/src/gloss.typ
@@ -122,12 +122,9 @@
   ),
 
   // split content lines into word arrays.
-  // error traces do not go through context (https://github.com/PgBiel/elembic/issues/84),
-  // so we must do all the validation here
+  // error traces do not go through context (https://github.com/PgBiel/elembic/issues/84), so we must do all the validation here
   construct: constructor => (..args) => {
-    // ISSUE: we can't control whether split happens on single spaces
-    // using a show rule,
-    // because we do that in the constructor
+    // NOTE: we can't control whether split happens on single spaces using a show rule, because we do that in the constructor
     let lines = args.pos().map(split-content)
     assert(lines.len() > 0, message: "at least one gloss line must be present")
 

--- a/src/gloss.typ
+++ b/src/gloss.typ
@@ -134,7 +134,7 @@
     // guard against invalid line lengths
     let length = lines.at(0).len()
     for line in lines {
-      assert(line.len() == length, message: "gloss lines have different lengths.\ntip: make sure that spaces you don't want to split on are non-breakable (`~`)")
+      assert(line.len() == length, message: "gloss lines have different lengths")
     }
 
     constructor(..lines, ..args.named())


### PR DESCRIPTION
Minor docs fixes. I've also added a commit to remove the tip about non-breaking spaces, given that it is well-documented elsewhere and under the assumption the user is going to be seeing that message a lot (while typing glosses) while non-breaking spaces are somewhat of a niche use case (I haven't found need for them yet).