### PR TITLE
Support for generating semantic HTML

### DIFF
--- a/src/example.typ
+++ b/src/example.typ
@@ -1,44 +1,12 @@
 #import "@preview/elembic:1.1.1" as e
 
 #import "gloss.typ": gloss
-#import "utils.typ": auto-length, gen-get-function, prefix
+#import "utils.typ": auto-length, gen-get-function, prefix, update-counter
 #import "ex-label.typ": ex-label, get-ex-label
 #import "judge.typ": judge, format-judges
 
-
 #let ctr = counter("eggsample")
 #let fn-ctr = counter("fn-eggsample")
-
-// trim a counter, removing all values after `level`
-#let reset-at(..args, level: 0) = {
-  let c = args.pos()
-  if c.len() > level + 1 {
-    return c.slice(0, level + 1)
-  }
-  return c
-}
-
-// either step the counter or trim it
-#let update-counter(ctr, level: 0, increment: true) = {
-  if increment {
-    // increment only if no custom number is sent
-    ctr.step(level: level + 1)
-  } else {
-    // since the counter is not stepped,
-    // prevent subexample numbering from being continued from the previous example
-    ctr.update(reset-at.with(level: level))
-  }
-}
-
-
-// generate a sub label of the form parent-label:n,
-// getting n from the counter
-#let auto-sub-label(parent-label) = label(
-  str(parent-label)
-  + ":"
-  + (numbering("a", ctr.get().at(1, default: 0) + 1))
-)
-
 
 #let build-subexample(elem) = {
   let number = if elem.number != none {
@@ -47,36 +15,27 @@
     elem._counter.get().at(1) // the subexample counter is at level 1
   }
 
-  let into-glosses(enabled) = it => {
-    if enabled {
+  let elem-with-autos = {
+    // note that subexamples can never have subexamples themselves
+    show list: it => if elem.auto-glosses {
       gloss(..it.children.map(it => it.body))
     } else {
       it
     }
-  }
-
-  let show-with-autos(elem) = {
-    // note that subexamples can never have subexamples themselves
-    show list: into-glosses(elem.auto-glosses)
     format-judges(elem.body, auto-judges: elem.auto-judges)
   }
 
-  show: it => {
-    set block(spacing: (elem.get-spacing)())
-    // for wrapping examples in a grid
-    set grid(row-gutter: (elem.get-spacing)())
-    it
-  }
+  set block(spacing: (elem.get-spacing)())
+  set grid(row-gutter: (elem.get-spacing)())
 
   // if we're targeting html... what's important are semantic notions, not rendering specifics.
   // so we consider a subexample to be an `<li>` (within an `<ol>` of some example).
   if "html" in dictionary(std) and target() == "html" {
-    html.elem("li", attrs: (class: "subeggsample", value: str(number)),
-      show-with-autos(elem))
+    html.elem("li", attrs: (class: "subeggsample", value: str(number)), elem-with-autos)
   } else {
     block(inset: (left: elem.indent),
       grid(columns: (elem.body-indent, 1fr),
-        numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem))))
+        numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, elem-with-autos)))
   }
 }
 
@@ -179,7 +138,8 @@
       // only use context when needed to generate auto labels
       if lbl == none and args.at("_parent-label", default: none) != none {
         context {
-          let lbl = auto-sub-label(args.at("_parent-label"))
+          // build a sub label of the form parent-label:n, getting n from the counter
+          let lbl = label(str(args.at("_parent-label")) + ":" + (numbering("a", ctr.get().at(1, default: 0) + 1)))
           constructor(..args, label: lbl)
         }
       } else {
@@ -226,43 +186,26 @@
     elem._counter.get().at(0) // the example counter is at level 0
   }
 
-  let into-subexamples(enabled, subexample-wrapper: none, parent-number: none, parent-label: none) = it => {
-    if enabled {
-      subexample-wrapper(..it.children.map(item =>
-        subexample(item.body, _parent-number: parent-number, _parent-label: parent-label)))
+  let elem-with-autos = {
+    show enum: it => if elem.auto-subexamples {
+      let subexample-wrapper = elem.at("subexample-wrapper", default: none)
+      let subexample-func = subexample.with(
+        _parent-number: elem.number,
+        _parent-label: if elem.auto-subexamples and elem.auto-labels { elem.at("label", default: none) } else { none })
+      subexample-wrapper(..it.children.map(item => subexample-func(item.body)))
     } else {
       it
     }
-  }
-
-  let into-glosses(enabled) = it => {
-    if enabled {
+    show list: it => if elem.auto-glosses {
       gloss(..it.children.map(it => it.body))
     } else {
       it
     }
-  }
-
-  let show-with-autos(elem) = {
-    show enum: into-subexamples(elem.auto-subexamples,
-      subexample-wrapper: elem.at("subexample-wrapper", default: none),
-      parent-number: elem.at("number", default: none),
-      parent-label: if elem.auto-subexamples and elem.auto-labels {
-        elem.at("label", default: none)
-      } else {
-        none
-      }
-    )
-    show list: into-glosses(elem.auto-glosses)
-
     format-judges(elem.body, auto-judges: elem.auto-judges)
   }
 
-  show: it => {
-    set block(spacing: (elem.get-spacing)())
-    set grid(row-gutter: (elem.get-spacing)())
-    it
-  }
+  set block(spacing: (elem.get-spacing)())
+  set grid(row-gutter: (elem.get-spacing)())
 
   // if we're targeting html... what's important are semantic notions, not rendering specifics.
   // so we consider an example to be an `<li>`, within a singleton `<ol>`.
@@ -270,11 +213,11 @@
   if "html" in dictionary(std) and target() == "html" {
     html.elem("ol", attrs: (class: "eggsample"),
       html.elem("li", attrs: (value: str(number)),
-        html.elem("ol", show-with-autos(elem))))
+        html.elem("ol", elem-with-autos)))
   } else {
     block(inset: (left: elem.indent),
       grid(columns: (elem.body-indent, 1fr),
-        numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem))))
+        numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, elem-with-autos)))
   }
 }
 

--- a/src/example.typ
+++ b/src/example.typ
@@ -68,8 +68,9 @@
     it
   }
 
-  grid(columns: (elem.indent, elem.body-indent, 1fr),
-    [], numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem)))
+  block(inset: (left: elem.indent),
+    grid(columns: (elem.body-indent, 1fr),
+      numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem))))
 }
 
 /// Second-level linguistic subexample. Only intended for use inside an example.
@@ -256,8 +257,9 @@
     it
   }
 
-  grid(columns: (elem.indent, elem.body-indent, 1fr),
-    [], numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem)))
+  block(inset: (left: elem.indent),
+    grid(columns: (elem.body-indent, 1fr),
+      numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, example-body)))
 }
 
 /// Top-level linguistic example.

--- a/src/example.typ
+++ b/src/example.typ
@@ -40,35 +40,13 @@
 )
 
 
-// assemble the example
-#let build-example(
-  elem,
-  // use recursion with early binding
-  // per https://github.com/typst/typst/issues/744#issuecomment-2343319015
-  subexample-func: none,
-  number: none,
-  level: 0,
-  kind: none
-) = {
-
-  // turn a list into subexamples
-  let into-subexamples(enabled, level: 0, subexample-wrapper: none, parent-number: none, parent-label: none) = it => {
-    if enabled {
-      subexample-wrapper(
-        ..it.children.map(item => {
-          subexample-func(
-            item.body,
-            _parent-number: parent-number,
-            _parent-label: parent-label,
-          )
-        })
-      )
-    } else {
-      it
-    }
+#let build-subexample(elem) = {
+  let number = if elem.number != none {
+    elem.number
+  } else {
+    elem._counter.get().at(1) // the subexample counter is at level 1
   }
 
-  // turn a list into glosses
   let into-glosses(enabled) = it => {
     if enabled {
       gloss(..it.children.map(it => it.body))
@@ -77,14 +55,8 @@
     }
   }
 
-  let show-with-autos(elem, level: 0, parent-number: none, parent-label: none) = {
-    show enum: into-subexamples(
-      elem.auto-subexamples,
-      level: 0,
-      subexample-wrapper: elem.at("subexample-wrapper", default: "none"),
-      parent-number: parent-number,
-      parent-label: parent-label
-    )
+  let show-with-autos(elem) = {
+    // note that subexamples can never have subexamples themselves
     show list: into-glosses(elem.auto-glosses)
     format-judges(elem.body, auto-judges: elem.auto-judges)
   }
@@ -96,22 +68,8 @@
     it
   }
 
-  grid(
-    columns: (elem.indent, elem.body-indent, 1fr),
-    [],
-    numbering(
-      elem.num-pattern,
-      if elem.number != none { elem.number } else { elem._counter.get().at(level) }
-    ),
-    grid.cell(
-      show-with-autos(
-        elem,
-        level: level,
-        parent-number: elem.at("number", default: none),
-        parent-label: if elem.auto-subexamples and elem.auto-labels { elem.at("label", default: none) } else { none }
-      ),
-      breakable: elem.breakable),
-  )
+  grid(columns: (elem.indent, elem.body-indent, 1fr),
+    [], numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem)))
 }
 
 /// Second-level linguistic subexample. Only intended for use inside an example.
@@ -192,7 +150,7 @@
     e.field("body-indent", length, default: 1.5em, doc: "Distance between the left edge of the subexample marker and the left edge of the subexample body."),
     e.field("spacing", auto-length, default: auto, doc: "Vertical spacing around the subexample. Currently, there is no way to modify spacing between two subexamples specifically."),
     e.field("breakable", bool, default: false, doc: "Whether the subexample figure is breakable."),
-    
+
     e.field("num-pattern", e.types.union(str, function), default: "a.", doc: "Subexample number format."),
     e.field("ref-pattern", e.types.union(str, function), default: "1a", doc: "Example reference format (without brackets). A 2-level numbering pattern."),
     e.field("second-sub-ref-pattern", str, default: "a", doc: "Format to reference the second argument of `ex-ref` if it is a subexample. A 1-level numbering pattern."),
@@ -204,7 +162,7 @@
     e.field("auto-subexamples", bool, synthesized: true),
     e.field("get-spacing", function, synthesized: true, default: () => par.leading)
   ),
-  
+
   construct: constructor => (..args) => {
     if args.named().at("label", default: none) != none {
       constructor(..args)
@@ -253,12 +211,58 @@
     }
   ),
 
-  display: it => build-example(
-    it,
-    level: 1,
-  )
+  display: it => build-subexample(it)
 )
 
+
+#let build-example(elem) = {
+  let number = if elem.number != none {
+    elem.number
+  } else {
+    elem._counter.get().at(0) // the example counter is at level 0
+  }
+
+  let into-subexamples(enabled, subexample-wrapper: none, parent-number: none, parent-label: none) = it => {
+    if enabled {
+      subexample-wrapper(..it.children.map(item =>
+        subexample(item.body, _parent-number: parent-number, _parent-label: parent-label)))
+    } else {
+      it
+    }
+  }
+
+  let into-glosses(enabled) = it => {
+    if enabled {
+      gloss(..it.children.map(it => it.body))
+    } else {
+      it
+    }
+  }
+
+  let show-with-autos(elem) = {
+    show enum: into-subexamples(elem.auto-subexamples,
+      subexample-wrapper: elem.at("subexample-wrapper", default: none),
+      parent-number: elem.at("number", default: none),
+      parent-label: if elem.auto-subexamples and elem.auto-labels {
+        elem.at("label", default: none)
+      } else {
+        none
+      }
+    )
+    show list: into-glosses(elem.auto-glosses)
+
+    format-judges(elem.body, auto-judges: elem.auto-judges)
+  }
+
+  show: it => {
+    set block(spacing: (elem.get-spacing)())
+    set grid(row-gutter: (elem.get-spacing)())
+    it
+  }
+
+  grid(columns: (elem.indent, elem.body-indent, 1fr),
+    [], numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem)))
+}
 
 /// Top-level linguistic example.
 ///
@@ -382,9 +386,5 @@
     )
   ),
 
-  display: it => build-example(
-    subexample-func: subexample,
-    it,
-    level: 0,
-  )
+  display: it => build-example(it)
 )

--- a/src/example.typ
+++ b/src/example.typ
@@ -68,9 +68,16 @@
     it
   }
 
-  block(inset: (left: elem.indent),
-    grid(columns: (elem.body-indent, 1fr),
-      numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem))))
+  // if we're targeting html... what's important are semantic notions, not rendering specifics.
+  // so we consider a subexample to be an `<li>` (within an `<ol>` of some example).
+  if "html" in dictionary(std) and target() == "html" {
+    html.elem("li", attrs: (class: "subeggsample", value: str(number)),
+      show-with-autos(elem))
+  } else {
+    block(inset: (left: elem.indent),
+      grid(columns: (elem.body-indent, 1fr),
+        numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem))))
+  }
 }
 
 /// Second-level linguistic subexample. Only intended for use inside an example.
@@ -257,9 +264,18 @@
     it
   }
 
-  block(inset: (left: elem.indent),
-    grid(columns: (elem.body-indent, 1fr),
-      numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, example-body)))
+  // if we're targeting html... what's important are semantic notions, not rendering specifics.
+  // so we consider an example to be an `<li>`, within a singleton `<ol>`.
+  // this `<li>` contains an `<ol>`, which may possibly contain `<li>` subexamples.
+  if "html" in dictionary(std) and target() == "html" {
+    html.elem("ol", attrs: (class: "eggsample"),
+      html.elem("li", attrs: (value: str(number)),
+        html.elem("ol", show-with-autos(elem))))
+  } else {
+    block(inset: (left: elem.indent),
+      grid(columns: (elem.body-indent, 1fr),
+        numbering(elem.num-pattern, number), grid.cell(breakable: elem.breakable, show-with-autos(elem))))
+  }
 }
 
 /// Top-level linguistic example.

--- a/src/example.typ
+++ b/src/example.typ
@@ -159,7 +159,6 @@
     e.field("_counter", counter, default: counter("eggsample"), doc: "The example counter. Set automatically and differs in footnotes."),
     e.field("_parent-number", e.types.option(int), doc: "Top-level example number, when overriden. Set automatically."),
     e.field("_parent-label", e.types.option(label), doc: "Top-level example label for auto-labels. Set automatically."),
-    e.field("auto-subexamples", bool, synthesized: true),
     e.field("get-spacing", function, synthesized: true, default: () => par.leading)
   ),
 
@@ -181,10 +180,7 @@
     }
   },
 
-  synthesize: it => {
-    it.auto-subexamples = false
-    gen-get-function(it, ("spacing", par.leading))
-  },
+  synthesize: it => gen-get-function(it, ("spacing", par.leading)),
 
   // using custom counter
   count: _ => it => update-counter(it._counter, level: 1, increment: it.number == none),

--- a/src/gloss.typ
+++ b/src/gloss.typ
@@ -15,28 +15,20 @@
   leading: auto,
   hanging-indent: auto,
 ) = {
-  let length = lines.at(0).len()
-  block(
-    above: before-spacing,
-    below: after-spacing,
+  // transpose a list of lines into a list of columns
+  let gloss-units(lines) = lines.at(0).zip(..lines.slice(1))
+  let style-units(words, styles) = words
+    // parse each word for auto judges
+    .map(format-judges.with(auto-judges: auto-judges))
+    // apply corresponding styling to each word
+    .zip(styles)
+    .map(((word, style)) => style(word))
 
+  block(above: before-spacing, below: after-spacing,
     par(hanging-indent: hanging-indent, leading: leading,
-      // turn list of lines into list of columns
-      lines.at(0).zip(..lines.slice(1))
-      .map(words => {
-        box(
-          grid(
-            row-gutter: line-spacing,
-            ..words
-              // parse each word for auto judges
-              .map(format-judges.with(auto-judges: auto-judges))
-              // apply corresponding styling to each word
-              .zip(styles)
-              .map(((word, style)) => style(word))
-          )
-        )
-        h(word-spacing)
-      }).join()
+      for words in gloss-units(lines) { // note: this is a joining `for`, loop results are appended together
+        box(grid(row-gutter: line-spacing, ..style-units(words, styles))) + h(word-spacing)
+      }
     )
   )
 }

--- a/src/gloss.typ
+++ b/src/gloss.typ
@@ -24,13 +24,28 @@
     .zip(styles)
     .map(((word, style)) => style(word))
 
-  block(above: before-spacing, below: after-spacing,
-    par(hanging-indent: hanging-indent, leading: leading,
-      for words in gloss-units(lines) { // note: this is a joining `for`, loop results are appended together
-        box(grid(row-gutter: line-spacing, ..style-units(words, styles))) + h(word-spacing)
-      }
+  // if we're targeting html, we compile glosses to `<table>`, since we're giving a semantic representation.
+  if "html" in dictionary(std) and target() == "html" {
+    html.elem("table", attrs: (class: "gloss", style: "border-spacing: 1em 0;"),
+      html.elem("tbody",
+        for words in lines { // note: this is a joining `for`, loop results are appended together
+          html.elem("tr",
+            for word in words {
+              html.elem("td", format-judges(word, auto-judges: auto-judges))
+            }
+          )
+        }
+      )
     )
-  )
+  } else {
+    block(above: before-spacing, below: after-spacing,
+      par(hanging-indent: hanging-indent, leading: leading,
+        for words in gloss-units(lines) { // note: this is a joining `for`, loop results are appended together
+          box(grid(row-gutter: line-spacing, ..style-units(words, styles))) + h(word-spacing)
+        }
+      )
+    )
+  }
 }
 
 /// Interlinear gloss grid.

--- a/src/utils.typ
+++ b/src/utils.typ
@@ -16,7 +16,7 @@
 
 // in all text-type children,
 // find `from` string and replace it with `to` content
-// returning an array of content 
+// returning an array of content
 #let replace-text-with-content(it, from: " ", to: [ ]) = {
   if it.has("text") {
     it.text.split(from).map(text).intersperse(to)
@@ -60,12 +60,35 @@
     if type(head) == content {
       if head.func() == [ ].func() {
         return tail
-      } else if head.func() == text {
+      }
+      if head.func() == text {
         return text(head.text.trim(at: start)) + tail
       }
     }
   }
-  return it
+  it
+}
+
+// trim a counter, removing all values after `level`
+#let reset-counter-at(..args, level: 0) = {
+  let c = args.pos()
+  if c.len() > level + 1 {
+    c.slice(0, level + 1)
+  } else {
+    c
+  }
+}
+
+// either step the counter or trim it
+#let update-counter(ctr, level: 0, increment: true) = {
+  if increment {
+    // increment only if no custom number is sent
+    ctr.step(level: level + 1)
+  } else {
+    // since the counter is not stepped,
+    // prevent subexample numbering from being continued from the previous example
+    ctr.update(reset-counter-at.with(level: level))
+  }
 }
 
 #let prefix = "eggs07"


### PR DESCRIPTION
Closes #37.

This generates HTML output directly, semantically, checking if we are in an HTML target context and generating `<ol>` / `<li>` / various `<div>` elements directly. I think this is the correct approach to take for HTML support -- turns out, `grid` not being implemented doesn't really matter too much, since the approach upstream Typst is taking to HTML support (which I agree with) is semantics-first, styling-last.

---

The semantic representation of `example` and `subexample` is that of an `<ol>` and an `<li>`. As any subexample is necessarily nested within an example, I think this makes sense; and it lets us reuse HTML's semantic `value` attribute for numbering. Something I'm really unsure about, though, is the representation of top-level examples. Right now an `example` is compiled to the following:
```html
<div style="display: flex; flex-direction: row;">
  <p>(numbering)</p>
  <ol>subexamples / example body</ol>
</div>
```

There are a couple of problems with this. First, the `<ol>` is always present, even when there are no subexamples i.e. `<li>` elements. I think this is probably fine, it's a *little* weird but I think it's the correct representation. More pressingly, these examples are not *semantically numbered*. The number in `<p>` is raw content; it would be better to number examples semantically, but I can't think of a way! (Sans wrapping the whole document in `<ol>` and having examples be `<li>`, which I don't consider workable.) 

Another slight problem is the position of the numbering requires inline CSS... though that's probably fine. Once Typst supports outputting CSS style sheets we can change this to `.example {display: flex; flex-direction: row}`; for now inline CSS is totally acceptable IMO.

Subexamples are represented really nicely as `<li>`, I think, except that currently `elem.num-pattern` is not respected. This is probably fixable; I just haven't gotten around to it yet.

A styling problem (not the focus of this PR, but worth mentioning) is that neither `example` nor `subexample` respect `elem.indent`, `elem.body-indent`, or `elem.breakable` for the HTML target.

---

The semantic representation of `gloss` is currently that of a `<div>` containing a bunch of nested `<div>`s, grouping together their aligned entries. I am... not quite happy with this, actually, and am going to rework it -- grouping together aligned entries is reasonable semantically IMO, but there's the quite-big operational problem of that this breaks copy-paste. How I'll likely rewrite this is to have all the words linear in the HTML left-to-right, top-to-bottom... and align them with the power of CSS grid. I was having a lot of issues with wrapping when I was playing around with CSS grid earlier, but I think they're fixable.

---

There's quite a lot more work to be done here, but I think this is almost ready to merge as a start! Supporting HTML will be really nice, I think this has the potential to be very useful for educational curriculums, writing blog posts, etc.

This only touches `example` and `gloss` so far -- `gloss` needs to be reworked, but everything else -- `trailing`, `judge` (though `judge` is probably fine), labels/references -- still need to be examined and supported. I am not quite sure how labels/references work in the HTML output in general, actually.