### PR TITLE
gloss trailing

### DIFF
--- a/src/gloss.typ
+++ b/src/gloss.typ
@@ -121,15 +121,22 @@
         par(hanging-indent: hanging-indent, leading: leading,
           // turn list of lines into list of columns
           cols
-          .map(words => {
+          .zip(
+            (false,) * (cols.len() - 1) + (true,)
+          )
+          .map(((words, final)) => {
             box(
               grid(
                 row-gutter: line-spacing,
-                ..words
-              )
+                ..words,
+              ),
+              // the final box takes the whole remaining width
+              // to properly align trailing citations
+              ..if final and words.any(word => metadata("eggs-trailing") in word.children) {
+                (width: 1fr)
+              }
             )
-            h(word-spacing)
-          }).join()
+          }).join(h(word-spacing))
         )
       )
     }

--- a/src/trailing.typ
+++ b/src/trailing.typ
@@ -13,24 +13,25 @@
 /// *Default*: 1.5em
 ///
 /// -> content
-#let trailing(body, gap: 1.5em) = context if is-html() {
-    context {
-      html.elem("span",
-        attrs: (
-          class: "eggs-trailing",
-          ..if html-align-trailing.get() {(
-            style: html-style(
-              float: "right"
-            )
-          )}
-        ),
-        body
-      )    
-    }
+#let trailing(body, gap: 1.5em) = {
+  // need this for gloss lines to be sensitive to trailing
+  context if is-html() {
+    html.elem("span",
+      attrs: (
+        class: "eggs-trailing",
+        ..if html-align-trailing.get() {(
+          style: html-style(
+            float: "right"
+          )
+        )}
+      ),
+      body
+    )    
   } else {
     box()
     h(1fr)
     sym.wj
     box({h(gap); body})
   }
-
+  metadata("eggs-trailing")
+}


### PR DESCRIPTION
implements #35

use as

```typst
#example[
  - #lorem(4) #trailing[trailing]
  - #lorem(4) ~
]
```

this is ugly: it adds a single-purpose metadata to `trailing` and single-use special treatment of the final word + content parsing to `gloss`.

issue:
- when the trailing doesn't fit, it doesn't wrap but extends over the page margin.

the metadata is basically needed in order for this to not happen to non-trailing final words when the glosses should wrap on them
