### PR TITLE
align gloss chunks at the top of the bounding box in case of varying heights of lines

### DIFF
--- a/src/gloss.typ
+++ b/src/gloss.typ
@@ -122,7 +122,7 @@
           // turn list of lines into list of columns
           cols
           .map(words => {
-            box(
+            box(baseline: top,
               grid(
                 row-gutter: line-spacing,
                 ..words


### PR DESCRIPTION
I'm using Eggs for a book transcription, in which there are a bunch of glosses with lots of English text written under each single word. The density doesn't line up, and so the original book compensates for this by making the text very small + wrapping it with `#linebreak()`. Currently in Eggs, the gloss chunk bounding boxes are centered, so any inconsistencies in height will mess up their alignment.

Before: 
<img width="868" height="404" alt="image" src="https://github.com/user-attachments/assets/9a58b887-7341-42f3-8161-2da191ddbb5a" />

Passing `baseline: top` to the already-existing `box` invocation fixes it.
 
<img width="878" height="406" alt="image" src="https://github.com/user-attachments/assets/eb5640d8-412e-4939-9483-90959ce0d6d7" />

This does mean that if the *top* gloss line is of an inconsistent height, the bottom ones will be misaligned (unless `box(baseline: bottom)` was used), but I don't think this is remotely a common scenario / worth exposing a config option for.

This shouldn't have any effect on glosses of consistent heights (most of them).